### PR TITLE
🔀 :: (#11) Aws SQS 설정하기

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,14 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USERNAME}
     url: jdbc:mysql://${DB_URL}:3306/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+logging.level.com.amazonaws.util.EC2MetadataUtils: error


### PR DESCRIPTION
```
2022-02-20 03:57:26.850  INFO 93811 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean '(inner bean)#43d38654' of type [com.amazonaws.auth.BasicAWSCredentials] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
2022-02-20 03:57:26.850  INFO 93811 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean '(inner bean)#1290c49' of type [com.amazonaws.auth.AWSStaticCredentialsProvider] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
2022-02-20 03:57:26.854  INFO 93811 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean '(inner bean)#1daf3b44' of type [com.amazonaws.auth.profile.ProfileCredentialsProvider] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
2022-02-20 03:57:26.856  INFO 93811 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'credentialsProvider' of type [org.springframework.cloud.aws.core.credentials.CredentialsProviderFactoryBean] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
2022-02-20 03:57:26.856  INFO 93811 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'credentialsProvider' of type [com.amazonaws.auth.AWSCredentialsProviderChain] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
```
이게 뜨는데 불편해서 해결방법 알면 코멘트 부탁 ㅜㅜ