### PR TITLE
🔀 :: (#3) SQSlistener에서 파라미터 안받아져오는 에러

### DIFF
--- a/notification-infrastructure/src/main/kotlin/io/github/v1servicenotification/domain/notification/presentation/dto/Group.kt
+++ b/notification-infrastructure/src/main/kotlin/io/github/v1servicenotification/domain/notification/presentation/dto/Group.kt
@@ -1,8 +1,10 @@
 package io.github.v1servicenotification.domain.notification.presentation.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
 data class Group(
+    @JsonProperty("category_id")
     val categoryId: UUID,
 
     val title: String,

--- a/notification-infrastructure/src/main/kotlin/io/github/v1servicenotification/domain/notification/presentation/dto/Personal.kt
+++ b/notification-infrastructure/src/main/kotlin/io/github/v1servicenotification/domain/notification/presentation/dto/Personal.kt
@@ -1,11 +1,15 @@
 package io.github.v1servicenotification.domain.notification.presentation.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
 data class Personal(
-    val categoryId: UUID,
 
+    @JsonProperty("user_id")
     val userId: UUID,
+
+    @JsonProperty("category_id")
+    val categoryId: UUID,
 
     val title: String,
 


### PR DESCRIPTION
Group, Person DTO에서 MissingKotlinParameterException가 발생 Json값을 categoryId이런식으로 받아와 오류가 터짐.
 JsonProperty로 category_id이런 형식의 json으로 받아오도록 수정