### PR TITLE
🔀 :: (#211) 알림 비활성화 시, 개인 알림 버그 해결

### DIFF
--- a/notification-domain/src/main/kotlin/io/github/v1servicenotification/detail/service/NotificationDetailApiImpl.kt
+++ b/notification-domain/src/main/kotlin/io/github/v1servicenotification/detail/service/NotificationDetailApiImpl.kt
@@ -100,11 +100,9 @@ class NotificationDetailApiImpl(
 
         val category = queryCategoryRepositorySpi.findByTopic(topic)
 
-        val userId = if (category.defaultActivated) {
+        if (category.defaultActivated && postDetailSettingRepositorySpi.findIsActivatedByUserIdAndTopic(userId, topic)) {
             // 기본값이 true면 Setting에서 false로 설정한 사람을 제외하고 발송한다.
-            postDetailSettingRepositorySpi.findUserIdByTopicAndIsActivated(topic, false)
-        } else {
-            postDetailSettingRepositorySpi.findUserIdByTopicAndIsActivated(topic, true)
+            postDetailFcmSpi.sendMessage(postDetailUserSpi.getDeviceToken(userId), category.title, content, threadId)
         }
 
         postDetailRepositorySpi.save(
@@ -117,8 +115,6 @@ class NotificationDetailApiImpl(
                 categoryId = category.id,
             )
         )
-
-        postDetailFcmSpi.sendMessage(postDetailUserSpi.getDeviceToken(userId), category.title, content, threadId)
     }
 
     override fun queryNotificationDetail(userId: UUID): DetailResponse {

--- a/notification-domain/src/main/kotlin/io/github/v1servicenotification/detail/service/NotificationDetailApiImpl.kt
+++ b/notification-domain/src/main/kotlin/io/github/v1servicenotification/detail/service/NotificationDetailApiImpl.kt
@@ -100,6 +100,13 @@ class NotificationDetailApiImpl(
 
         val category = queryCategoryRepositorySpi.findByTopic(topic)
 
+        val userId = if (category.defaultActivated) {
+            // 기본값이 true면 Setting에서 false로 설정한 사람을 제외하고 발송한다.
+            postDetailSettingRepositorySpi.findUserIdByTopicAndIsActivated(topic, false)
+        } else {
+            postDetailSettingRepositorySpi.findUserIdByTopicAndIsActivated(topic, true)
+        }
+
         postDetailRepositorySpi.save(
             Detail(
                 title = category.title,

--- a/notification-domain/src/main/kotlin/io/github/v1servicenotification/detail/spi/PostDetailSettingRepositorySpi.kt
+++ b/notification-domain/src/main/kotlin/io/github/v1servicenotification/detail/spi/PostDetailSettingRepositorySpi.kt
@@ -4,4 +4,5 @@ import java.util.UUID
 
 interface PostDetailSettingRepositorySpi {
     fun findAllUserIdByTopicAndIsActivated(topic: String, isActivated: Boolean): List<UUID>
+    fun findUserIdByTopicAndIsActivated(topic: String, isActivated: Boolean): UUID
 }

--- a/notification-domain/src/main/kotlin/io/github/v1servicenotification/detail/spi/PostDetailSettingRepositorySpi.kt
+++ b/notification-domain/src/main/kotlin/io/github/v1servicenotification/detail/spi/PostDetailSettingRepositorySpi.kt
@@ -4,5 +4,5 @@ import java.util.UUID
 
 interface PostDetailSettingRepositorySpi {
     fun findAllUserIdByTopicAndIsActivated(topic: String, isActivated: Boolean): List<UUID>
-    fun findUserIdByTopicAndIsActivated(topic: String, isActivated: Boolean): UUID
+    fun findIsActivatedByUserIdAndTopic(userId: UUID, topic: String): Boolean
 }

--- a/notification-domain/src/main/kotlin/io/github/v1servicenotification/stubs/InMemorySettingRepository.kt
+++ b/notification-domain/src/main/kotlin/io/github/v1servicenotification/stubs/InMemorySettingRepository.kt
@@ -57,4 +57,8 @@ class InMemorySettingRepository(
             categoryMap[it.value.notificationCategoryId] ?: throw CategoryNotFoundException.EXCEPTION
         }
     }
+
+    override fun findIsActivatedByUserIdAndTopic(userId: UUID, topic: String): Boolean {
+        return settingMap.values.filter { it.userId == userId && categoryMap[it.notificationCategoryId]?.topic == topic }.all { it.isActivated }
+    }
 }

--- a/notification-domain/src/main/kotlin/io/github/v1servicenotification/stubs/InMemorySettingRepository.kt
+++ b/notification-domain/src/main/kotlin/io/github/v1servicenotification/stubs/InMemorySettingRepository.kt
@@ -59,6 +59,8 @@ class InMemorySettingRepository(
     }
 
     override fun findIsActivatedByUserIdAndTopic(userId: UUID, topic: String): Boolean {
-        return settingMap.values.filter { it.userId == userId && categoryMap[it.notificationCategoryId]?.topic == topic }.all { it.isActivated }
+        return settingMap.values.filter {
+            it.userId == userId && categoryMap[it.notificationCategoryId]?.topic == topic
+        }.all { it.isActivated }
     }
 }

--- a/notification-infrastructure/src/main/kotlin/io/github/v1servicenotification/domain/setting/domain/repository/CustomSettingRepositoryImpl.kt
+++ b/notification-infrastructure/src/main/kotlin/io/github/v1servicenotification/domain/setting/domain/repository/CustomSettingRepositoryImpl.kt
@@ -103,6 +103,5 @@ class CustomSettingRepositoryImpl(
                     .and(categoryEntity.topic.eq(topic))
             )
             .fetchFirst()
-
     }
 }

--- a/notification-infrastructure/src/main/kotlin/io/github/v1servicenotification/domain/setting/domain/repository/CustomSettingRepositoryImpl.kt
+++ b/notification-infrastructure/src/main/kotlin/io/github/v1servicenotification/domain/setting/domain/repository/CustomSettingRepositoryImpl.kt
@@ -92,4 +92,17 @@ class CustomSettingRepositoryImpl(
             )
             .fetch()
     }
+
+    override fun findIsActivatedByUserIdAndTopic(userId: UUID, topic: String): Boolean {
+        return jpaQueryFactory
+            .select(settingEntity.isActivated)
+            .from(settingEntity)
+            .leftJoin(settingEntity.settingId.categoryEntity, categoryEntity)
+            .where(
+                settingEntity.settingId.userId.eq(userId)
+                    .and(categoryEntity.topic.eq(topic))
+            )
+            .fetchFirst()
+
+    }
 }


### PR DESCRIPTION
- 알림을 비활성화 했을 경우, 개인으로 알림 보내는 메소드에서 활성화 체크 로직을 짜지 않아 알림을 꺼도 알림이 발송되는 버그
